### PR TITLE
Update WorkerSinkTask.java

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -634,7 +634,6 @@ class WorkerSinkTask extends WorkerTask {
     }
 
     private void openPartitions(Collection<TopicPartition> partitions) {
-        updatePartitionCount();
         task.open(partitions);
     }
 
@@ -655,7 +654,6 @@ class WorkerSinkTask extends WorkerTask {
             }
             currentOffsets.keySet().removeAll(topicPartitions);
         }
-        updatePartitionCount();
         lastCommittedOffsets.keySet().removeAll(topicPartitions);
     }
 
@@ -721,7 +719,7 @@ class WorkerSinkTask extends WorkerTask {
                 else if (!context.pausedPartitions().isEmpty())
                     consumer.pause(context.pausedPartitions());
             }
-
+            updatePartitionCount();
             if (partitions.isEmpty()) {
                 return;
             }


### PR DESCRIPTION
In case of the revocation of partitions, the updation of "**partition count**" metrics is being done before updating the new set of assignments. "**invokePartitionsRevoked**" method of "**onJoinComplete**" function of "**ConsumerCoordinator**" class is being called before the "
**subscriptions.assignFromSubscribed(assignedPartitions)**" of the same class. As a result of which the old assigned partition count is getting updated again and again even after future rebalances.